### PR TITLE
Add support for configuring Git author

### DIFF
--- a/app/src/main/java/io/github/wiiznokes/gitnote/manager/StorageManager.kt
+++ b/app/src/main/java/io/github/wiiznokes/gitnote/manager/StorageManager.kt
@@ -60,11 +60,12 @@ class StorageManager {
 
         val cred = prefs.cred()
         val remoteUrl = prefs.remoteUrl.get()
+        val author = prefs.gitAuthor()
 
 
 
         gitManager.commitAll(
-            prefs.usernameOrDefault(),
+            author,
             "commit from gitnote to update the repo of the app"
         ).onFailure {
             uiHelper.makeToast(it.message)
@@ -305,9 +306,10 @@ class StorageManager {
 
         val cred = prefs.cred()
         val remoteUrl = prefs.remoteUrl.get()
+        val author = prefs.gitAuthor()
 
         gitManager.commitAll(
-            prefs.usernameOrDefault(),
+            author,
             "commit from gitnote, before doing a change"
         ).onFailure {
             return failure(it)
@@ -333,7 +335,7 @@ class StorageManager {
             }
         )
 
-        gitManager.commitAll(prefs.usernameOrDefault(), commitMessage).onFailure {
+        gitManager.commitAll(author, commitMessage).onFailure {
             return failure(it)
         }
 

--- a/app/src/main/java/io/github/wiiznokes/gitnote/ui/model/GitAuthor.kt
+++ b/app/src/main/java/io/github/wiiznokes/gitnote/ui/model/GitAuthor.kt
@@ -1,0 +1,6 @@
+package io.github.wiiznokes.gitnote.ui.model
+
+data class GitAuthor(
+    val name: String,
+    val email: String
+)

--- a/app/src/main/java/io/github/wiiznokes/gitnote/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/wiiznokes/gitnote/ui/screen/settings/SettingsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Button
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
@@ -21,6 +22,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.olshevski.navigation.reimagined.NavController
 import dev.olshevski.navigation.reimagined.navigate
 import io.github.wiiznokes.gitnote.BuildConfig
@@ -198,6 +200,28 @@ fun SettingsScreen(
             title = stringResource(R.string.repository)
         ) {
 
+            val gitAuthorFlow = remember { vm.prefs.gitAuthorFlow() }
+            val gitAuthor by gitAuthorFlow
+                .collectAsStateWithLifecycle(initialValue = vm.prefs.gitAuthorBlocking())
+            StringSettings(
+                title = stringResource(R.string.git_author_name),
+                subtitle = gitAuthor.name,
+                stringValue = gitAuthor.name,
+                onChange = { updated ->
+                    vm.update { vm.prefs.gitAuthorName.update(updated.trim()) }
+                }
+            )
+
+            StringSettings(
+                title = stringResource(R.string.git_author_email),
+                subtitle = gitAuthor.email,
+                stringValue = gitAuthor.email,
+                onChange = { updated ->
+                    vm.update { vm.prefs.gitAuthorEmail.update(updated.trim()) }
+                },
+                keyboardType = KeyboardType.Email
+            )
+
             val remoteUrl by vm.prefs.remoteUrl.getAsState()
             StringSettings(
                 title = stringResource(R.string.remote_url),
@@ -313,4 +337,3 @@ fun SettingsScreen(
         }
     }
 }
-

--- a/app/src/main/java/io/github/wiiznokes/gitnote/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/io/github/wiiznokes/gitnote/ui/viewmodel/MainViewModel.kt
@@ -52,6 +52,7 @@ class MainViewModel : ViewModel() {
         gitManager.openRepo(storageConfig.repoPath()).onFailure {
             return false
         }
+        prefs.applyGitAuthorDefaults(gitManager.currentSignature())
 
         CoroutineScope(Dispatchers.IO).launch {
             storageManager.updateDatabaseAndRepo()

--- a/app/src/main/java/io/github/wiiznokes/gitnote/ui/viewmodel/SetupViewModel.kt
+++ b/app/src/main/java/io/github/wiiznokes/gitnote/ui/viewmodel/SetupViewModel.kt
@@ -123,6 +123,7 @@ class SetupViewModel(val authFlow: SharedFlow<String>) : ViewModel(), SetupViewM
                 return@launch
             }
 
+            prefs.applyGitAuthorDefaults(gitManager.currentSignature())
             prefs.initRepo(storageConfig)
 
             storageManager.updateDatabase()
@@ -146,6 +147,7 @@ class SetupViewModel(val authFlow: SharedFlow<String>) : ViewModel(), SetupViewM
                 return@launch
             }
 
+            prefs.applyGitAuthorDefaults(gitManager.currentSignature())
             prefs.initRepo(storageConfig)
 
             storageManager.updateDatabaseAndRepo()
@@ -222,6 +224,7 @@ class SetupViewModel(val authFlow: SharedFlow<String>) : ViewModel(), SetupViewM
         prefs.remoteUrl.update(remoteUrl)
 
         prefs.updateCred(cred)
+        prefs.applyGitAuthorDefaults(gitManager.currentSignature())
 
         storageManager.updateDatabase(
             progressCb = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,8 @@
     <string name="password">Password</string>
     <string name="username">Username</string>
     <string name="remote_url">Remote url</string>
+    <string name="git_author_name">Git author name</string>
+    <string name="git_author_email">Git author email</string>
     <string name="close_repository">Close repository</string>
     <string name="close_repository_confirmation">Do you really want to close the repository?</string>
     <string name="version">Version</string>


### PR DESCRIPTION
Adds new fields in the repository section of the settings screen to support configuring the Git name/email author fields. Fallback to the current default (`gitnote`).

This can be useful for GitHub's UI or just for `git log` customisation.

<img width="864" height="1920" alt="Screenshot_20251204-163508" src="https://github.com/user-attachments/assets/ed03a962-f4ae-4a87-b3fe-1512607eb397" />
