### PR TITLE
Support active branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ _Supported Architecture: `arm64-v8a`, `x86_64`_
 
 # Current limitation
 
-- Only repositories with a branch "main" are supported
 - Android does not differentiate case for file name, so if you have a folder named `A` and another folder named `a`, `a` will not be displayed.
 - Conflict will make the app crash
 


### PR DESCRIPTION
Push/pull now resolves the active/default branch from the repo's `HEAD`, so any branch name works instead of a hardcoded `main`.

Closes #91, closes #120.
