### PR TITLE
Simplify new note floating action button

### DIFF
--- a/app/src/main/java/io/github/wiiznokes/gitnote/ui/screen/app/grid/BottomGrid.kt
+++ b/app/src/main/java/io/github/wiiznokes/gitnote/ui/screen/app/grid/BottomGrid.kt
@@ -1,50 +1,17 @@
 package io.github.wiiznokes.gitnote.ui.screen.app.grid
 
-import android.util.Log
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.AnimatedVisibilityScope
-import androidx.compose.animation.core.MutableTransitionState
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntRect
-import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.PopupPositionProvider
 import io.github.wiiznokes.gitnote.data.room.Note
 import io.github.wiiznokes.gitnote.ui.model.EditType
 import io.github.wiiznokes.gitnote.ui.viewmodel.GridViewModel
 import kotlin.math.roundToInt
-
-private const val TAG = "GridViewBottom"
 
 
 @Composable
@@ -52,161 +19,18 @@ fun FloatingActionButtons(
     vm: GridViewModel,
     offset: Float,
     onEditClick: (Note, EditType) -> Unit,
-    searchFocusRequester: FocusRequester,
-    expanded: MutableState<Boolean>,
 ) {
 
-    val keyboardController = LocalSoftwareKeyboardController.current
-
-    FABs(
-        expanded = expanded,
+    FloatingActionButton(
         modifier = Modifier
             .offset { IntOffset(x = 0, y = -offset.roundToInt()) },
-        items = listOf(
-            FABItem(
-                icon = Icons.Default.Add,
-                label = "create",
-                type = FABItemType.CREATE,
-                containerColor = MaterialTheme.colorScheme.tertiary
-            ),
-            FABItem(
-                icon = Icons.Default.Search,
-                label = "search",
-                type = FABItemType.SEARCH,
-            ),
-        ),
-        onItemClicked = {
-
-            when (it.type) {
-                FABItemType.CREATE -> {
-                    onEditClick(
-                        vm.defaultNewNote(),
-                        EditType.Create
-                    )
-                }
-
-                FABItemType.SEARCH -> {
-                    searchFocusRequester.requestFocus()
-                    keyboardController?.show()
-                }
-            }
+        onClick = {
+            onEditClick(vm.defaultNewNote(), EditType.Create)
         },
-    )
-}
-
-/**
- * FloatingActionButtons
- */
-@Composable
-private fun FABs(
-    modifier: Modifier = Modifier,
-    items: List<FABItem>,
-    onItemClicked: (fabItem: FABItem) -> Unit,
-    expanded: MutableState<Boolean>,
-) {
-
-    val rotation by animateFloatAsState(
-        if (expanded.value) {
-            45f
-        } else {
-            0f
-        }, label = "FabRotate"
-    )
-
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        ListFab(
-            expanded = expanded
-        ) {
-            LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(15.dp)
-            ) {
-                items(items) { item ->
-
-                    FloatingActionButton(
-                        modifier = Modifier.size(50.dp),
-                        onClick = {
-                            expanded.value = false
-                            onItemClicked(item)
-                        },
-                        containerColor = item.containerColor
-                            ?: FloatingActionButtonDefaults.containerColor,
-                    ) {
-                        Icon(
-                            imageVector = item.icon,
-                            contentDescription = item.label,
-                        )
-                    }
-                }
-                item { }
-                item { } // Empty items to provide spacing at the end of the list
-            }
-        }
-
-        FloatingActionButton(
-            modifier = modifier,
-            onClick = {
-                expanded.value = !expanded.value
-            },
-        ) {
-            Icon(
-                imageVector = Icons.Filled.Add,
-                contentDescription = null,
-                modifier = Modifier.rotate(rotation),
-            )
-        }
+        Icon(
+            imageVector = Icons.Default.Add,
+            contentDescription = "create note",
+        )
     }
 }
-
-private data class FABItem(
-    val icon: ImageVector,
-    val label: String,
-    val type: FABItemType,
-    val containerColor: Color? = null,
-)
-
-private enum class FABItemType {
-    CREATE,
-    SEARCH
-}
-
-@Composable
-private fun ListFab(
-    expanded: MutableState<Boolean>,
-    content: @Composable AnimatedVisibilityScope.() -> Unit
-) {
-    val expandedState = remember { MutableTransitionState(false) }
-    expandedState.targetState = expanded.value
-
-    AnimatedVisibility(
-        visibleState = expandedState,
-        content = content,
-        enter = fadeIn() + expandVertically(),
-        exit = fadeOut() + shrinkVertically(),
-    )
-}
-
-private object FABPopupPositionProvider
-    : PopupPositionProvider {
-    override fun calculatePosition(
-        anchorBounds: IntRect,
-        windowSize: IntSize,
-        layoutDirection: LayoutDirection,
-        popupContentSize: IntSize
-    ): IntOffset {
-
-        Log.d(TAG, "anchorBounds = $anchorBounds")
-        Log.d(TAG, "windowSize = $windowSize")
-        Log.d(TAG, "popupContentSize = $popupContentSize")
-
-        val rightOffset = anchorBounds.left + anchorBounds.width / 2 - popupContentSize.width / 2
-        val topOffset = anchorBounds.top - popupContentSize.height
-        val offset = IntOffset(rightOffset, topOffset)
-
-        Log.d(TAG, "offset = $offset")
-        return offset
-
-    }
-}
-

--- a/app/src/main/java/io/github/wiiznokes/gitnote/ui/screen/app/grid/GridScreen.kt
+++ b/app/src/main/java/io/github/wiiznokes/gitnote/ui/screen/app/grid/GridScreen.kt
@@ -121,10 +121,6 @@ fun GridScreen(
 
         val searchFocusRequester = remember { FocusRequester() }
 
-        val fabExpanded = remember {
-            mutableStateOf(false)
-        }
-
         val offset = remember { mutableFloatStateOf(0f) }
 
         Scaffold(
@@ -137,8 +133,6 @@ fun GridScreen(
                         vm = vm,
                         offset = offset.floatValue,
                         onEditClick = onEditClick,
-                        searchFocusRequester = searchFocusRequester,
-                        expanded = fabExpanded,
                     )
                 }
 
@@ -146,7 +140,6 @@ fun GridScreen(
 
             val nestedScrollConnection = rememberNestedScrollConnection(
                 offset = offset,
-                fabExpanded = fabExpanded,
             )
 
 
@@ -463,7 +456,6 @@ internal fun NoteActionsDropdown(
 @Composable
 private fun rememberNestedScrollConnection(
     offset: MutableFloatState,
-    fabExpanded: MutableState<Boolean>,
 ): NestedScrollConnection {
 
 
@@ -482,8 +474,6 @@ private fun rememberNestedScrollConnection(
             override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
                 //Log.d(TAG, "onPreScroll(available: ${available.y})")
                 if (!shouldBlock) keyboardController?.hide()
-
-                fabExpanded.value = false
 
                 return calculateOffset(available.y)
             }


### PR DESCRIPTION
Along the same lines as #63, I expected the "+" FAB to create a new note, not open a menu. Search is also duplicated in the header.

Having a single action improves the UX (in my opinion). Perhaps if new note types are later, this can be reworked.

Closes #63.
