### PR TITLE
Allow any character in the repository path part

### DIFF
--- a/app/src/main/java/io/github/wiiznokes/gitnote/ui/screen/setup/remote/EnterUrlScreen.kt
+++ b/app/src/main/java/io/github/wiiznokes/gitnote/ui/screen/setup/remote/EnterUrlScreen.kt
@@ -24,7 +24,7 @@ import io.github.wiiznokes.gitnote.ui.component.SetupButton
 import io.github.wiiznokes.gitnote.ui.component.SetupLine
 import io.github.wiiznokes.gitnote.ui.component.SetupPage
 
-private val sshGitRegex = Regex("""^(?:git@|ssh://git@)[\w.-]+:[\w./-]+(?:\.git)?$""")
+private val sshGitRegex = Regex("""^(?:git@|ssh://git@)[\w.-]+:.+(?:\.git)?$""")
 
 fun isUrlSsh(url: String): Boolean {
     return sshGitRegex.matches(url)


### PR DESCRIPTION
Unix filename can contain any character other than a slash or a \0. Since we're looking for a path, a slash is OK. I'm not sure how one would enter a nul-byte into an Android app.

closes #171 