### PR TITLE
Reinitialise repo on main activity (re)creation

### DIFF
--- a/app/src/main/java/io/github/wiiznokes/gitnote/MainActivity.kt
+++ b/app/src/main/java/io/github/wiiznokes/gitnote/MainActivity.kt
@@ -7,7 +7,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.remember
 import androidx.lifecycle.viewmodel.compose.viewModel
 import dev.olshevski.navigation.reimagined.AnimatedNavHost
 import dev.olshevski.navigation.reimagined.NavBackHandler
@@ -55,7 +55,7 @@ class MainActivity : ComponentActivity() {
                 dynamicColor = dynamicColor
             ) {
 
-                val startDestination: Destination = rememberSaveable {
+                val startDestination: Destination = remember {
                     if (runBlocking { vm.tryInit() }) {
                         Destination.App(AppDestination.Grid)
                     } else Destination.Setup(SetupDestination.Main)


### PR DESCRIPTION
This ensures the repo is properly opened if the main activity is killed/re-opened.

Tested via:

1. used this branch to add some debug logs: https://github.com/wiiznokes/gitnote/compare/master...tlvince:gitnote:repo-not-init-logs
2. started the app with network online (triggering a sync)
3. disable the network (via GrapheneOS' network permission toggle)
4. make a change to a note, saw the following logs:

 ```
   D StorageManager: update: commitMessage=gitnote modified gitnote.md, isRepoInitialized=false
   D GitManager:   safelyAccessLibGit2: commitAll (isRepoInitialized=false, isLibInitialized=false)
   D GitManager:   res on init = 0
   D GitManager:   commit all: <redacted>
   W GitManager:   commitAll: isRepoInitialized is false, throwing RepoNotInit
   W GitManager:   safelyAccessLibGit2: operation 'commitAll' failed
   W GitManager:   io.github.wiiznokes.gitnote.manager.GitException: RepoNotInit
   E StorageManager: update: commitAll (before) failed: RepoNotInit
 ```

With this and the same steps, after the process is recreated, `tryInit` runs and I can't repro.

Closes #196, closes #197.